### PR TITLE
Fix link to executable file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ esy install
 # Build dependencies
 esy build
 # Run the app
-_build/install/default/app.exe
+_build/install/App.exe
 ```
 
 > __NOTE:__ The first build will take a while - building the OCaml compiler and dependencies takes time! Subsequent builds, though, should be very fast.


### PR DESCRIPTION
The link to the executable that is created was `_build/install/App.exe` (not sure if this is platform specific) but directly following the instruction didn't work till I looked into the directory for the executable file