### PR TITLE
add format helper

### DIFF
--- a/App.re
+++ b/App.re
@@ -4,7 +4,6 @@ open Revery.UI;
 
 /* The 'main' function for our app */
 let init = app => {
-
   /* Create a window! */
   let w = App.createWindow(app, "test");
 
@@ -12,17 +11,35 @@ let init = app => {
   let ui = UI.create(w);
 
   /* Set up some styles */
-  let textHeaderStyle = Style.make(~backgroundColor=Colors.black, ~color=Colors.white, ~fontFamily="Lato-Regular.ttf", ~fontSize=24, ());
+  let textHeaderStyle =
+    Style.make(
+      ~backgroundColor=Colors.black,
+      ~color=Colors.white,
+      ~fontFamily="Lato-Regular.ttf",
+      ~fontSize=24,
+      (),
+    );
 
   /* Set up our render function */
-  Window.setRenderCallback(w, () => {
-
+  Window.setRenderCallback(w, ()
     /* This is where we render the UI - if you've used React or ReasonReact, it should look familiar */
-    UI.render(ui,
-        <view style=(Style.make(~position=LayoutTypes.Absolute, ~bottom=10, ~top=10, ~left=10, ~right=10, ~backgroundColor=Colors.black, ()))>
-            <text style=(textHeaderStyle)>"Hello World!"</text>
-        </view>);
-  });
+    =>
+      UI.render(
+        ui,
+        <view
+          style={Style.make(
+            ~position=LayoutTypes.Absolute,
+            ~bottom=10,
+            ~top=10,
+            ~left=10,
+            ~right=10,
+            ~backgroundColor=Colors.black,
+            (),
+          )}>
+          <text style=textHeaderStyle> "Hello World!" </text>
+        </view>,
+      )
+    );
 };
 
 /* Let's get this party started! */

--- a/esy.lock.json
+++ b/esy.lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "5cd72ef7479e5060bfd840cfe6f249f0",
+  "hash": "0aed26a448c3710abbe5caf13a44f263",
   "root": "root@path:./package.json",
   "node": {
     "root@path:./package.json": {
@@ -13,7 +13,7 @@
       "dependencies": [
         "@opam/dune@opam:1.5.1", "@opam/merlin@opam:3.2.2",
         "@opam/ocamlbuild@opam:0.12.0", "flex@github:bryphe/flex#a73c134",
-        "ocaml@4.6.7", "reason-reactify@1.0.0",
+        "ocaml@4.6.8", "reason-reactify@1.1.0",
         "revery@github:bryphe/revery#0ebcbaf"
       ]
     },
@@ -34,7 +34,7 @@
         "reason-fontkit@github:bryphe/reason-fontkit#9e4358e",
         "reason-gl-matrix@0.2.0",
         "reason-glfw@github:bryphe/reason-glfw#23e93cc",
-        "reason-reactify@1.0.0"
+        "reason-reactify@1.1.0"
       ]
     },
     "refmterr@3.1.9": {
@@ -48,21 +48,21 @@
       },
       "dependencies": [
         "@esy-ocaml/reason@3.3.7", "@opam/jbuilder@opam:transition",
-        "@opam/re@opam:1.7.3", "ocaml@4.6.7"
+        "@opam/re@opam:1.7.3", "ocaml@4.6.8"
       ]
     },
-    "reason-reactify@1.0.0": {
+    "reason-reactify@1.1.0": {
       "record": {
         "name": "reason-reactify",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "source":
-          "archive:https://registry.npmjs.org/reason-reactify/-/reason-reactify-1.0.0.tgz#sha1:64275706193b30cd5e25c348ad590115bd6c5898",
+          "archive:https://registry.npmjs.org/reason-reactify/-/reason-reactify-1.1.0.tgz#sha1:53bf2c8c052e1969f3892fe06229b89729c0a497",
         "files": [],
         "opam": null
       },
       "dependencies": [
         "@esy-ocaml/reason@3.3.7", "@opam/dune@opam:1.5.1",
-        "@opam/lambda-term@opam:1.13", "@opam/lwt@opam:4.1.0", "ocaml@4.6.7",
+        "@opam/lambda-term@opam:1.13", "@opam/lwt@opam:4.1.0", "ocaml@4.6.8",
         "refmterr@3.1.9"
       ]
     },
@@ -95,7 +95,7 @@
       },
       "dependencies": [
         "@esy-ocaml/reason@3.3.7", "@opam/dune@opam:1.5.1",
-        "@opam/js_of_ocaml-compiler@opam:3.2.1", "ocaml@4.6.7",
+        "@opam/js_of_ocaml-compiler@opam:3.2.1", "ocaml@4.6.8",
         "refmterr@3.1.9"
       ]
     },
@@ -111,17 +111,17 @@
         "@esy-ocaml/reason@3.3.7", "@opam/dune@opam:1.5.1",
         "esy-cmake@github:esy-packages/esy-cmake#37a86af",
         "esy-freetype2@github:bryphe/esy-freetype2#bdce79aa3",
-        "esy-harfbuzz@github:bryphe/esy-harfbuzz#c5a68d6e6ad99589cd350179c332d056049528d7",
+        "esy-harfbuzz@github:bryphe/esy-harfbuzz#c5a68d6",
         "reason-gl-matrix@0.2.0",
         "reason-glfw@github:bryphe/reason-glfw#23e93cc", "refmterr@3.1.9"
       ]
     },
-    "ocaml@4.6.7": {
+    "ocaml@4.6.8": {
       "record": {
         "name": "ocaml",
-        "version": "4.6.7",
+        "version": "4.6.8",
         "source":
-          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.6.7.tgz#sha1:5bfdf7f9b7752646c2a5ad3c9e4021180eeab704",
+          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.6.8.tgz#sha1:6a4167e7ceb8b97fb305a9414b9103f2a04e6f7b",
         "files": [],
         "opam": null
       },
@@ -139,13 +139,11 @@
         "@esy-ocaml/reason@3.3.7", "@opam/dune@opam:1.5.1", "refmterr@3.1.9"
       ]
     },
-    "esy-harfbuzz@github:bryphe/esy-harfbuzz#c5a68d6e6ad99589cd350179c332d056049528d7": {
+    "esy-harfbuzz@github:bryphe/esy-harfbuzz#c5a68d6": {
       "record": {
         "name": "esy-harfbuzz",
-        "version":
-          "github:bryphe/esy-harfbuzz#c5a68d6e6ad99589cd350179c332d056049528d7",
-        "source":
-          "github:bryphe/esy-harfbuzz#c5a68d6e6ad99589cd350179c332d056049528d7",
+        "version": "github:bryphe/esy-harfbuzz#c5a68d6",
+        "source": "github:bryphe/esy-harfbuzz#c5a68d6",
         "files": [],
         "opam": null
       },
@@ -189,7 +187,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/base-bytes@opam:base",
         "@opam/camomile@opam:1.0.1", "@opam/jbuilder@opam:transition",
-        "@opam/react@opam:1.2.1", "ocaml@4.6.7"
+        "@opam/react@opam:1.2.1", "ocaml@4.6.8"
       ]
     },
     "@opam/yojson@opam:1.4.1": {
@@ -210,7 +208,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/biniou@opam:1.2.0",
         "@opam/cppo@opam:1.6.5", "@opam/easy-format@opam:1.3.1",
-        "@opam/jbuilder@opam:transition", "ocaml@4.6.7"
+        "@opam/jbuilder@opam:transition", "ocaml@4.6.8"
       ]
     },
     "@opam/uchar@opam:0.0.2": {
@@ -230,7 +228,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/topkg@opam:1.0.0": {
@@ -250,7 +248,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0",
-        "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3", "ocaml@4.6.7"
+        "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3", "ocaml@4.6.8"
       ]
     },
     "@opam/result@opam:1.3": {
@@ -270,7 +268,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/react@opam:1.2.1": {
@@ -290,7 +288,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0",
-        "@opam/ocamlfind@opam:1.8.0", "@opam/topkg@opam:1.0.0", "ocaml@4.6.7"
+        "@opam/ocamlfind@opam:1.8.0", "@opam/topkg@opam:1.0.0", "ocaml@4.6.8"
       ]
     },
     "@opam/re@opam:1.7.3": {
@@ -310,7 +308,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/ppx_tools_versioned@opam:5.2.1": {
@@ -330,7 +328,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "@opam/ocaml-migrate-parsetree@opam:1.1.0", "ocaml@4.6.7"
+        "@opam/ocaml-migrate-parsetree@opam:1.1.0", "ocaml@4.6.8"
       ]
     },
     "@opam/ocamlfind@opam:1.8.0": {
@@ -397,7 +395,7 @@
         }
       },
       "dependencies": [
-        "@esy-ocaml/substs@0.0.1", "@opam/conf-m4@opam:1", "ocaml@4.6.7"
+        "@esy-ocaml/substs@0.0.1", "@opam/conf-m4@opam:1", "ocaml@4.6.8"
       ]
     },
     "@opam/ocamlbuild@opam:0.12.0": {
@@ -440,7 +438,7 @@
           }
         }
       },
-      "dependencies": [ "@esy-ocaml/substs@0.0.1", "ocaml@4.6.7" ]
+      "dependencies": [ "@esy-ocaml/substs@0.0.1", "ocaml@4.6.8" ]
     },
     "@opam/ocaml-migrate-parsetree@opam:1.1.0": {
       "record": {
@@ -459,7 +457,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.5.1",
-        "@opam/result@opam:1.3", "ocaml@4.6.7"
+        "@opam/result@opam:1.3", "ocaml@4.6.8"
       ]
     },
     "@opam/merlin-extend@opam:0.3": {
@@ -493,7 +491,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/cppo@opam:1.6.5",
-        "@opam/ocamlfind@opam:1.8.0", "ocaml@4.6.7"
+        "@opam/ocamlfind@opam:1.8.0", "ocaml@4.6.8"
       ]
     },
     "@opam/merlin@opam:3.2.2": {
@@ -514,27 +512,27 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.5.1",
         "@opam/ocamlfind@opam:1.8.0", "@opam/yojson@opam:1.4.1",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
-    "@opam/menhir@opam:20181026": {
+    "@opam/menhir@opam:20181113": {
       "record": {
         "name": "@opam/menhir",
-        "version": "opam:20181026",
+        "version": "opam:20181113",
         "source":
-          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20181026/archive.tar.gz#md5:7047bcffbdc50cffd70012f4da2210ec",
+          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20181113/archive.tar.gz#md5:69ce441a06ea131cd43e7b44c4303f3c",
         "files": [],
         "opam": {
           "name": "menhir",
-          "version": "20181026",
+          "version": "20181113",
           "opam":
-            "opam-version: \"2.0\"\nname: \"menhir\"\nversion: \"20181026\"\nsynopsis: \"An LR(1) parser generator\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gitlab.inria.fr/fpottier/menhir\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocaml\" {>= \"4.02\"}\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n]\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"\nurl {\n  src:\n    \"https://gitlab.inria.fr/fpottier/menhir/repository/20181026/archive.tar.gz\"\n  checksum: [\n    \"md5=7047bcffbdc50cffd70012f4da2210ec\"\n    \"sha512=1101a0e0a33625e11700a7a909334fdf4d2600acf8aa629b4de1982185a4aa8320b3eaa87db75b4c76dd4663f6e5b77740f70b92c6a109ba3496db6eeae4479b\"\n  ]\n}",
+            "opam-version: \"2.0\"\nname: \"menhir\"\nversion: \"20181113\"\nsynopsis: \"An LR(1) parser generator\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gitlab.inria.fr/fpottier/menhir\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocaml\" {>= \"4.02\"}\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n]\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"\nurl {\n  src:\n    \"https://gitlab.inria.fr/fpottier/menhir/repository/20181113/archive.tar.gz\"\n  checksum: [\n    \"md5=69ce441a06ea131cd43e7b44c4303f3c\"\n    \"sha512=4ddefcd71d305bfb933a4056da57e36c13c99ec6dfcc4695814798fbbd78b4d65828381ebcb0e58c4c0394105ac763af3d475474e05e408f7080315bc3cf6176\"\n  ]\n}",
           "override": null
         }
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0",
-        "@opam/ocamlfind@opam:1.8.0", "ocaml@4.6.7"
+        "@opam/ocamlfind@opam:1.8.0", "ocaml@4.6.8"
       ]
     },
     "@opam/lwt_react@opam:1.1.1": {
@@ -554,7 +552,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "@opam/lwt@opam:4.1.0", "@opam/react@opam:1.2.1", "ocaml@4.6.7"
+        "@opam/lwt@opam:4.1.0", "@opam/react@opam:1.2.1", "ocaml@4.6.8"
       ]
     },
     "@opam/lwt_ppx@opam:1.2.1": {
@@ -575,7 +573,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
         "@opam/lwt@opam:4.1.0", "@opam/ocaml-migrate-parsetree@opam:1.1.0",
-        "@opam/ppx_tools_versioned@opam:5.2.1", "ocaml@4.6.7"
+        "@opam/ppx_tools_versioned@opam:5.2.1", "ocaml@4.6.8"
       ]
     },
     "@opam/lwt_log@opam:1.1.0": {
@@ -595,7 +593,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "@opam/lwt@opam:4.1.0", "ocaml@4.6.7"
+        "@opam/lwt@opam:4.1.0", "ocaml@4.6.8"
       ]
     },
     "@opam/lwt@opam:4.1.0": {
@@ -616,7 +614,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/cppo@opam:1.6.5",
         "@opam/jbuilder@opam:transition", "@opam/ocamlfind@opam:1.8.0",
-        "@opam/result@opam:1.3", "ocaml@4.6.7"
+        "@opam/result@opam:1.3", "ocaml@4.6.8"
       ]
     },
     "@opam/lambda-term@opam:1.13": {
@@ -652,7 +650,7 @@
         "@esy-ocaml/substs@0.0.1", "@opam/camomile@opam:1.0.1",
         "@opam/jbuilder@opam:transition", "@opam/lwt@opam:4.1.0",
         "@opam/lwt_log@opam:1.1.0", "@opam/lwt_react@opam:1.1.1",
-        "@opam/react@opam:1.2.1", "@opam/zed@opam:1.6", "ocaml@4.6.7"
+        "@opam/react@opam:1.2.1", "@opam/zed@opam:1.6", "ocaml@4.6.8"
       ]
     },
     "@opam/js_of_ocaml-ppx@opam:3.2.0": {
@@ -674,7 +672,7 @@
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
         "@opam/js_of_ocaml@opam:3.2.0",
         "@opam/ocaml-migrate-parsetree@opam:1.1.0",
-        "@opam/ppx_tools_versioned@opam:5.2.1", "ocaml@4.6.7"
+        "@opam/ppx_tools_versioned@opam:5.2.1", "ocaml@4.6.8"
       ]
     },
     "@opam/js_of_ocaml-lwt@opam:3.2.1": {
@@ -695,7 +693,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
         "@opam/js_of_ocaml@opam:3.2.0", "@opam/js_of_ocaml-ppx@opam:3.2.0",
-        "@opam/lwt@opam:4.1.0", "ocaml@4.6.7"
+        "@opam/lwt@opam:4.1.0", "ocaml@4.6.8"
       ]
     },
     "@opam/js_of_ocaml-compiler@opam:3.2.1": {
@@ -717,7 +715,7 @@
         "@esy-ocaml/substs@0.0.1", "@opam/cmdliner@opam:1.0.2",
         "@opam/cppo@opam:1.6.5", "@opam/jbuilder@opam:transition",
         "@opam/ocamlfind@opam:1.8.0", "@opam/yojson@opam:1.4.1",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/js_of_ocaml@opam:3.2.0": {
@@ -740,7 +738,7 @@
         "@opam/js_of_ocaml-compiler@opam:3.2.1",
         "@opam/ocaml-migrate-parsetree@opam:1.1.0",
         "@opam/ppx_tools_versioned@opam:5.2.1", "@opam/uchar@opam:0.0.2",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/jbuilder@opam:transition": {
@@ -758,7 +756,7 @@
         }
       },
       "dependencies": [
-        "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.5.1", "ocaml@4.6.7"
+        "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.5.1", "ocaml@4.6.8"
       ]
     },
     "@opam/easy-format@opam:1.3.1": {
@@ -778,7 +776,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/dune@opam:1.5.1": {
@@ -801,7 +799,7 @@
           }
         }
       },
-      "dependencies": [ "@esy-ocaml/substs@0.0.1", "ocaml@4.6.7" ]
+      "dependencies": [ "@esy-ocaml/substs@0.0.1", "ocaml@4.6.8" ]
     },
     "@opam/cppo@opam:1.6.5": {
       "record": {
@@ -820,7 +818,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/base-unix@opam:base",
-        "@opam/jbuilder@opam:transition", "ocaml@4.6.7"
+        "@opam/jbuilder@opam:transition", "ocaml@4.6.8"
       ]
     },
     "@opam/conf-which@opam:1": {
@@ -873,7 +871,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0",
         "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3",
-        "@opam/topkg@opam:1.0.0", "ocaml@4.6.7"
+        "@opam/topkg@opam:1.0.0", "ocaml@4.6.8"
       ]
     },
     "@opam/camomile@opam:1.0.1": {
@@ -893,7 +891,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/biniou@opam:1.2.0": {
@@ -914,7 +912,7 @@
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/conf-which@opam:1",
         "@opam/easy-format@opam:1.3.1", "@opam/jbuilder@opam:transition",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@opam/base-unix@opam:base": {
@@ -949,7 +947,7 @@
       },
       "dependencies": [
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlfind@opam:1.8.0",
-        "ocaml@4.6.7"
+        "ocaml@4.6.8"
       ]
     },
     "@esy-ocaml/substs@0.0.1": {
@@ -973,10 +971,10 @@
         "opam": null
       },
       "dependencies": [
-        "@opam/dune@opam:1.5.1", "@opam/menhir@opam:20181026",
+        "@opam/dune@opam:1.5.1", "@opam/menhir@opam:20181113",
         "@opam/merlin-extend@opam:0.3",
         "@opam/ocaml-migrate-parsetree@opam:1.1.0",
-        "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3", "ocaml@4.6.7"
+        "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3", "ocaml@4.6.8"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "reason-reactify": "^1.0.0",
     "@opam/dune": "*"
   },
+  "scripts": {
+   "format": "bash -c \"refmt --in-place *.re\""
+  },
   "resolutions": {
     "revery": "github:bryphe/revery#0ebcbaf",
     "flex": "github:bryphe/flex#a73c134",
@@ -22,7 +25,7 @@
     "reason-glfw": "github:bryphe/reason-glfw#23e93cc",
     "esy-cmake": "github:esy-packages/esy-cmake#37a86af",
     "esy-freetype2": "github:bryphe/esy-freetype2#bdce79aa3",
-    "esy-harfbuzz": "github:bryphe/esy-harfbuzz#b9fcbe3"
+    "esy-harfbuzz": "github:bryphe/esy-harfbuzz#c5a68d6"
   },
   "devDependencies": {
     "ocaml": "~4.6.0",


### PR DESCRIPTION
This adds a format helper that can be run with `esy format`. This is intended for ci and non-ide workflows. I also set the esy-harfbuzz version to the one matching the lock file, which I didn't check in in the last pr.