### PR TITLE
add run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ A Revery application also needs these files:
 - `esy build`
 
 The binary will be in the `_build/install/default/bin` - you can run it like:
-- `_build/install/default/bin/App.exe`
+
+- `_build/install/default/bin/App`
+
+or with esy:
+
+- `esy run`
 
 ```
 # Clone the repository
@@ -39,7 +44,7 @@ esy install
 # Build dependencies
 esy build
 # Run the app
-_build/install/App.exe
+esy run
 ```
 
 > __NOTE:__ The first build will take a while - building the OCaml compiler and dependencies takes time! Subsequent builds, though, should be very fast.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@opam/dune": "*"
   },
   "scripts": {
-   "format": "bash -c \"refmt --in-place *.re\""
+   "format": "bash -c \"refmt --in-place *.re\"",
+   "run": "esy x App"
   },
   "devDependencies": {
     "ocaml": "~4.6.0",


### PR DESCRIPTION
This adds a convenient command for running the executable. The user shouldn't have to be aware of the path `_build/install/default/bin/`, since esy can run the executable and even give you the absolute path if you need it (`esy x which App`)