### PR TITLE
Add prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A Revery application also needs these files:
 
 - Install [Git](https://git-scm.com/)
 - Install [Esy](https://esy.sh/) __0.5.6+__
+- Install [libpng](http://www.libpng.org/pub/png/libpng.html) (`brew install libpng` for MacOS users)
+- Install [ragel](http://www.colm.net/open-source/ragel/) (`brew install ragel` for MacOS users)
 
 ### Build
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "pesy": "0.4.1",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be",
     "rebez": "github:jchavarri/rebez#46cbc183",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#dd933fc",
     "@opam/merlin-extend": "0.4"


### PR DESCRIPTION
Hello there, awesome job on Revery !

I was trying to setup the project but it failed for missing dependencies. 
It could be helpful to mention `ragel` and `libpng` libs in the prerequisites section.

I saw it was added at some point in the revery package but maybe removed later on ? https://github.com/revery-ui/revery/pull/151

I also removed a duplicate line in the package.json, not sure if you wanted to keep it or not