### PR TITLE
Dune: Remove reglfw dependency

### DIFF
--- a/dune
+++ b/dune
@@ -4,6 +4,5 @@
     (public_name App)
     (libraries
         bigarray
-        reglfw
         Revery
             ))


### PR DESCRIPTION
This dependency is not needed; and will cause issues down the road when we upgrade to an SDL2-based Revery.