### PR TITLE
Remove duplicate brisk-reconciler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",
     "pesy": "0.4.1",
-    "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#daa00be",
     "rebez": "github:jchavarri/rebez#46cbc183",
     "@brisk/brisk-reconciler": "github:briskml/brisk-reconciler#dd933fc",
     "@opam/merlin-extend": "0.4"


### PR DESCRIPTION
Removed duplicated `brisk-reconciler` resolution. I kept the more recent one (hopefully that's the good option :grin:)