### PR TITLE
Dependency: add esy-macdylibbundler

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1d8da6be56bddba4899983387981e3b5",
+  "checksum": "de7ab6bf250202b4df9c3e4d48d68a13",
   "root": "revery-quick-start@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -106,7 +106,8 @@
         "@opam/dune@opam:2.4.0@639d28a3"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/merlin@opam:3.3.3@d653b06a"
+        "ocaml@4.8.1000@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "@opam/merlin@opam:3.3.3@d653b06a"
       ]
     },
     "revery@github:revery-ui/revery#3c23304@d41d8cd9": {
@@ -513,6 +514,22 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "esy-macdylibbundler@0.4.5@d41d8cd9": {
+      "id": "esy-macdylibbundler@0.4.5@d41d8cd9",
+      "name": "esy-macdylibbundler",
+      "version": "0.4.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esy-macdylibbundler/-/esy-macdylibbundler-0.4.5.tgz#sha1:f4aeadafe072b8fce9603a6da3cd10fa15c23495"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "revery": "revery-ui/revery#3c23304",
     "@opam/dune": "*",
-    "timber": "1.0.0"
+    "timber": "1.0.0",
+    "esy-macdylibbundler": "*"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2",


### PR DESCRIPTION
Apparently needed for revery-packager on macOS