### PR TITLE
chore: remove unused background-color, move styles from component

### DIFF
--- a/src/App.re
+++ b/src/App.re
@@ -2,13 +2,13 @@ open Revery;
 open Revery.UI;
 open Revery.UI.Components;
 
+module Styles = {
+  open Style;
+
+  let text = [marginTop(24), color(Color.hex(Theme.darkBlue))];
+};
+
 let%component main = () => {
-  module Styles = {
-    open Style;
-
-    let text = [marginTop(24), color(Color.hex(Theme.darkBlue))];
-  };
-
   let%hook (count, setCount) = React.Hooks.state(0);
 
   let increment = () => setCount(count => count + 1);

--- a/src/SimpleButton.re
+++ b/src/SimpleButton.re
@@ -25,7 +25,7 @@ module Styles = {
     borderRadius(10.),
   ];
 
-  let buttonText = [backgroundColor(Colors.red), color(Colors.white)];
+  let buttonText = [color(Colors.white)];
 };
 
 let%component make = (~text, ~onClick, ()) => {


### PR DESCRIPTION
Noticed that there was a style-leftover and also moved the styles out of the component-definition for an (hopefully) easier overview of the component-logic.